### PR TITLE
Correct Reset Password Link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,3 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased]
+### Changed
+- HOST_NAME is now SERVER_NAME in the config
+
+### Fixed
+- Reset Password Link in emails

--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ To customize the entire default configuration, you can simply copy the distribut
 
 ### Import Settings and Overwrite Individually
 
-Another option is to import all the default settings and only overwrite certain settings. Here is an example of a minimal config.py file that imports default values and sets the database to a MySQL connection:
+Another option is to import all the default settings and only overwrite certain settings. Here is an example of a minimal config.py file that imports default values and sets the database to a MySQL connection and sets the address:
 
     from configdist import *
 
     DATABASE_URL = 'mysql://db_user:db_pass@db_host/db_name'
+    # SERVER_NAME must NOT have a protocol prefix (no http/https)
+    SERVER_NAME = 'localhost:5000'
 
 # Database
 

--- a/_15thnight/api/account.py
+++ b/_15thnight/api/account.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timedelta
-from flask import Blueprint, request, session, render_template, url_for
+from flask import Blueprint, request, render_template, url_for
 from flask.ext.login import (
     login_user, logout_user, login_required, current_user
 )
 from flask_mail import Message
-from werkzeug.datastructures import MultiDict
 
 from _15thnight.forms import (
     LoginForm, ChangePasswordForm, UpdateProfileForm, ResetPasswordForm,
@@ -72,11 +71,12 @@ def forgot_password():
     user = User.get_by_email(form.email.data)
     if user:
         if (not user.reset_token or
-            user.reset_created_at < datetime.utcnow() - reset_token_life):
+                user.reset_created_at < datetime.utcnow() - reset_token_life):
             user.generate_reset_token()
         user.save()
-        link = '%sreset-password/%s/%s' % (url_for('index', _external=True),
-            user.email, user.reset_token)
+        link = '%sreset-password/%s/%s' % (
+            url_for('index', _external=True), user.email, user.reset_token
+        )
         message = Message(
             subject='15th Night Password Reset Link',
             body=render_template('email/reset_instructions.txt', link=link),
@@ -107,7 +107,6 @@ def reset_password():
     user.reset_token = None
     user.reset_created_at = None
     user.save()
-    current_time = datetime.utcnow()
     data = dict(
         time=datetime.utcnow().strftime('%m/%d/%y %I:%M%p'),
         ip=request.remote_addr
@@ -121,7 +120,6 @@ def reset_password():
     queue_send_email.apply_async(kwargs=dict(message=message))
     login_user(user)
     return jsonify(user)
-
 
 
 @account_api.route('/change-password', methods=['POST'])

--- a/_15thnight/core.py
+++ b/_15thnight/core.py
@@ -5,11 +5,6 @@ from _15thnight.models import (
     Alert, Need, NeedProvided, ProviderNotified, Service, Response, User
 )
 
-try:
-    from config import HOST_NAME
-except:
-    from configdist import HOST_NAME
-
 
 def send_out_alert(alert_form):
     """
@@ -39,7 +34,8 @@ def send_out_alert(alert_form):
                 'Desc: %s\n'
                 'Respond at %s/r/%s') % (
                     alert.age, gender, needs,
-                    alert_form.description.data, HOST_NAME, str(alert.id)
+                    alert_form.description.data, url_for(
+                        '/', _external=True), str(alert.id)
                 )
         provider_notified = ProviderNotified(
             provider=provider,

--- a/configdist.py
+++ b/configdist.py
@@ -31,7 +31,8 @@ MAIL_USE_SSL = False
 TWILIO_TEST_NUMBER = ""
 
 SECRET_KEY = 'This is not secret you must change it'
-HOST_NAME = 'http://localhost:5000'
+PREFERRED_URL_SCHEME = "http"
+SERVER_NAME = 'localhost:5000'
 
 CELERY_BROKER = "sqla+%s" % DATABASE_URL
 DEBUG = True


### PR DESCRIPTION
fixes #156

Use Flask's SERVER_NAME instead of our HOST_NAME

Fixes Reset Password Link URL issue.

REMEMBER:
Rename HOST_NAME to SERVER_NAME and remove the protocol (http:///https://).