### PR TITLE
view alert reponses for admins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Reset Password Link in emails
+- Admins can view alert responses

--- a/_15thnight/api/alert.py
+++ b/_15thnight/api/alert.py
@@ -51,7 +51,7 @@ def get_alert(alert_id):
             return api_error('Permission denied')
         data = alert.to_advocate_json()
     else: # is an admin
-        data = alert.to_json()
+        data = alert.to_advocate_json()
     return jsonify(data)
 
 

--- a/client/src/components/pages/advocate/ViewResponsesPage.js
+++ b/client/src/components/pages/advocate/ViewResponsesPage.js
@@ -52,6 +52,7 @@ class ViewResponsesPage extends React.Component {
 
     render() {
         let { alert } = this.state;
+        let { current_user } = this.props;
         if (!alert) {
             return (<h1 className="text-center">Loading Alert...</h1>);
         }
@@ -89,14 +90,15 @@ class ViewResponsesPage extends React.Component {
                                         { need.resolved_at }
                                         <br/>
                                     </div> :
-                                    <div>
-                                        <Link
-                                          className="btn btn-success"
-                                          to={'/resolve-need/' + need.id}
-                                        >
-                                            Mark as Resolved
-                                        </Link>
-                                    </div>
+                                    current_user.role === 'advocate' &&
+                                        <div>
+                                            <Link
+                                              className="btn btn-success"
+                                              to={'/resolve-need/' + need.id}
+                                            >
+                                                Mark as Resolved
+                                            </Link>
+                                        </div>
                                 }
                                 {
                                     this.state.showResolveHistory[need.id] &&
@@ -133,6 +135,7 @@ class ViewResponsesPage extends React.Component {
 
 function mapStateToProps(state) {
     return {
+        current_user: state.current_user,
         alert: state.alert
     }
 }

--- a/client/src/routes/AdminRoutes.js
+++ b/client/src/routes/AdminRoutes.js
@@ -9,6 +9,8 @@ import {
     UserFormPage
 } from 'pages/admin';
 
+// TODO: refactor pages into structure based on API, not roles
+import { ViewResponsesPage } from 'pages/advocate';
 
 const childRoutes = [
     { path: '/'                  , component: AdminAlertHistoryPage },
@@ -25,7 +27,9 @@ const childRoutes = [
 
     { path: '/edit-user/:id'     , component: UserFormPage },
     { path: '/edit-category/:id' , component: CategoryFormPage },
-    { path: '/edit-service/:id'  , component: ServiceFormPage }
+    { path: '/edit-service/:id'  , component: ServiceFormPage },
+
+    { path: '/view-responses/:id' , component: ViewResponsesPage}
 ]
 
 export default { childRoutes }


### PR DESCRIPTION
This is a bare-minimum fix for adding functionality to admin users for viewing responses.

We will eventually want to refactor the organization of pages by API functionality and not by role.

We will also want to eventually clean up the render method and JSX in the `ViewResponsesPage` component. 